### PR TITLE
Adjust security workflow reference

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,7 @@ permissions: read-all
 
 jobs:
   ossf:
-    uses: TBD54566975/open-source-programs/.github/workflows/scorecard.yml@main
+    uses: block/ospo/.github/workflows/scorecard.yml@main
     secrets: inherit
     permissions:
       security-events: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - leordev/* # TODO: remove this before merge
 
   # Run every day at 5am UTC
   schedule:
@@ -18,5 +19,5 @@ on:
 
 jobs:
   security-license-scan:
-    uses: TBD54566975/open-source-programs/.github/workflows/security.yml@main
+    uses: block/ospo/.github/workflows/security.yml@main
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - leordev/* # TODO: remove this before merge
 
   # Run every day at 5am UTC
   schedule:


### PR DESCRIPTION
# Overview
Adjust the workflow  security file reference to use the new Block/Ospo one.

# How Has This Been Tested?
- [X] [Workflow run](https://github.com/block/example-java-kotlin-maven-multimodule/actions/runs/11844310349/job/33007222739) - note that the FOSSA task has failed but it's expected for the first time since we dont have any scans on main for the diff comparison in the PR.

# Checklist
- [X] I have read the CONTRIBUTING document.
- [X] My code is consistent with the rest of the project 
- [X] I have tagged the relevant reviewers and/or interested parties
- [X] I have updated the READMEs and other documentation of affected packages

Fix #13 and #14