### PR TITLE
Add DCO verification workflow to all commits and PRs

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -1,0 +1,20 @@
+name: DCO Verification
+on:
+  pull_request:
+  push:
+jobs:
+  dco-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Python 3.x
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.x'
+      - name: Check DCO
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DCO_CHECK_VERBOSE: '1'
+        run: |
+          pip3 install -U dco-check
+          dco-check --exclude-pattern '@(block.xyz|squareup.com|cash.app)$'


### PR DESCRIPTION
This adds a new GitHub Actions workflow to all pushes and PRs to ensure that all commits in the push or the PR either have a Developer Certificate of Origin (DCO) or were made by someone with a Block-issued email address. This is a first pass to get the minimum functionality, and has lots of room to grow